### PR TITLE
Added app name to Crashlytics init

### DIFF
--- a/crashlytics/lib/ds_crashlytics.dart
+++ b/crashlytics/lib/ds_crashlytics.dart
@@ -19,9 +19,9 @@ final crashlyticsProvider = Provider<FirebaseCrashlytics?>(
 
 mixin CrashlyticsLoader {
   Future<FirebaseCrashlytics?> startCrashlytics(WidgetRef ref,
-      {FirebaseOptions? options}) async {
+      {String? name, FirebaseOptions? options}) async {
     // Wait for Firebase to initialize
-    await Firebase.initializeApp(options: options);
+    await Firebase.initializeApp(name: name, options: options);
 
     final crashlytics = ref.read(crashlyticsProvider);
     await crashlytics?.setCrashlyticsCollectionEnabled(kReleaseMode);


### PR DESCRIPTION
Fix for error:
[[core/duplicate-app] A Firebase App named "[DEFAULT]" already exists](https://stackoverflow.com/questions/69987065/errorflutter-lib-ui-ui-dart-state-cc209-unhandled-exception-core-duplicate)