### PR TITLE
fix: handle all DioException connection errors, not just failed host lookup (ZET-352)

### DIFF
--- a/utils/lib/src/networking.dart
+++ b/utils/lib/src/networking.dart
@@ -247,8 +247,8 @@ class HTTPRequest {
         .catchError(_handleNetworkIssues,
             test: (e) =>
                 e is DioException &&
-                e.type == DioExceptionType.connectionError &&
-                (e.message?.toLowerCase().contains('failed host lookup') ?? false));
+                (e.type == DioExceptionType.connectionError ||
+                    e.type == DioExceptionType.connectionTimeout));
   }
 
   Future<T> run<T>(


### PR DESCRIPTION
## Summary
- Broadened the `DioException` connection error handler in `utils/lib/src/networking.dart` to catch **all** `DioExceptionType.connectionError` and `DioExceptionType.connectionTimeout` types
- Previously, only connection errors containing "failed host lookup" in the message were caught, causing other connection failures (e.g., "Connection failed") to bubble up as unhandled exceptions to Sentry

## Implementation
The `execute()` method's `.catchError` test function was overly restrictive:

**Before:** Only matched `connectionError` with message containing `'failed host lookup'`
**After:** Matches all `connectionError` and `connectionTimeout` DioException types

These are now properly converted to `NetworkConnectionError`, which the app's state management layer already handles gracefully by setting `_isConnectedToNetwork = false`.

## Testing
- `dart analyze` passes with no issues
- No test suite exists in this package

## Linear Issue
[ZET-352](https://linear.app/zettellc/issue/ZET-352/dioexception-dioexception-connection-error-the-connection-errored)

## Sentry Issue
https://sentry.io/organizations/zette-dev/issues/7375072067/events/17fc8d881a224a97b310fd937460e1c5/

🤖 Generated with [Claude Code](https://claude.com/claude-code)